### PR TITLE
Fix deprecated `set-output` command

### DIFF
--- a/last_tag.sh
+++ b/last_tag.sh
@@ -59,7 +59,7 @@ function main() { # main function
   # Output the versions
   if [ "${GITHUB_ENV}" !=  '' ]; then
      echo "LAST_TAG=${LAST_TAG}" >> $GITHUB_ENV
-     echo "::set-output name=last_tag::${LAST_TAG}"
+     echo "last_tag=${LAST_TAG}" >> $GITHUB_OUTPUT
   else
      echo "LAST_TAG=${LAST_TAG}"
   fi


### PR DESCRIPTION
As of October 11th, 2022, `set-output` was marked as deprecated and will be fully disabled.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/